### PR TITLE
subgraph: add usdai stats and transfer volume history

### DIFF
--- a/subgraph/.gitignore
+++ b/subgraph/.gitignore
@@ -34,4 +34,5 @@ typechain-types
 cache
 
 # Tests
-tests
+tests/.bin
+tests/.latest.json

--- a/subgraph/package-lock.json
+++ b/subgraph/package-lock.json
@@ -9,6 +9,9 @@
         "@graphprotocol/graph-cli": "0.97.1",
         "@graphprotocol/graph-ts": "0.37.0",
         "prettier": "^3.6.2"
+      },
+      "devDependencies": {
+        "matchstick-as": "0.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3450,6 +3453,16 @@
       "integrity": "sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==",
       "license": "Apache-2.0 OR MIT"
     },
+    "node_modules/matchstick-as": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/matchstick-as/-/matchstick-as-0.6.0.tgz",
+      "integrity": "sha512-E36fWsC1AbCkBFt05VsDDRoFvGSdcZg6oZJrtIe/YDBbuFh8SKbR5FcoqDhNWqSN+F7bN/iS2u8Md0SM+4pUpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "wabt": "1.0.24"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4669,6 +4682,24 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/wabt": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.24.tgz",
+      "integrity": "sha512-8l7sIOd3i5GWfTWciPL0+ff/FK/deVK2Q6FN+MPz4vfUcD78i2M/49XJTwF6aml91uIiuXJEsLKWMB2cw/mtKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-decompile": "bin/wasm-decompile",
+        "wasm-interp": "bin/wasm-interp",
+        "wasm-objdump": "bin/wasm-objdump",
+        "wasm-opcodecnt": "bin/wasm-opcodecnt",
+        "wasm-strip": "bin/wasm-strip",
+        "wasm-validate": "bin/wasm-validate",
+        "wasm2c": "bin/wasm2c",
+        "wasm2wat": "bin/wasm2wat",
+        "wat2wasm": "bin/wat2wasm"
       }
     },
     "node_modules/wcwidth": {

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -5,11 +5,15 @@
     "codegen": "graph codegen subgraph.yaml",
     "build:arbitrum": "graph build --network arbitrum-one subgraph.yaml",
     "build:mainnet": "graph build --network mainnet subgraph.yaml",
-    "build:sepolia": "graph build --network sepolia subgraph.yaml"
+    "build:sepolia": "graph build --network sepolia subgraph.yaml",
+    "test": "graph test"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.97.1",
     "@graphprotocol/graph-ts": "0.37.0",
     "prettier": "^3.6.2"
+  },
+  "devDependencies": {
+    "matchstick-as": "0.6.0"
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -9,3 +9,18 @@ type Predeposit @entity(immutable: true) {
   timestamp: BigInt!
   transactionHash: Bytes!
 }
+
+type USDaiStats @entity(immutable: false) {
+  id: Bytes!
+  totalVolume: BigInt! # Cumulative transfer amount
+  transferCount: BigInt!
+}
+
+type USDaiMonthData @entity(immutable: false) {
+  id: Bytes! # Year-month encoded (e.g., "2026-01")
+  year: Int! # Year (e.g., 2026)
+  month: Int! # Month (1-12)
+  timestamp: BigInt! # Start of month timestamp (for sorting/filtering)
+  volume: BigInt! # Total transfer volume for this month
+  transferCount: BigInt! # Number of transfers
+}

--- a/subgraph/src/usdai.ts
+++ b/subgraph/src/usdai.ts
@@ -1,0 +1,42 @@
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { Transfer as TransferEvent } from "../generated/USDai/USDai";
+import { USDaiStats, USDaiMonthData } from "../generated/schema";
+import { getYearAndMonth, getMonthStartTimestamp, createMonthId } from "./utils";
+
+const STATS_ID = Bytes.fromUTF8("stats");
+
+export function handleTransfer(event: TransferEvent): void {
+  // Update cumulative stats
+  let stats = USDaiStats.load(STATS_ID);
+
+  if (stats == null) {
+    stats = new USDaiStats(STATS_ID);
+    stats.totalVolume = BigInt.fromI32(0);
+    stats.transferCount = BigInt.fromI32(0);
+  }
+
+  stats.totalVolume = stats.totalVolume.plus(event.params.value);
+  stats.transferCount = stats.transferCount.plus(BigInt.fromI32(1));
+  stats.save();
+
+  // Update monthly aggregation
+  const yearMonth = getYearAndMonth(event.block.timestamp);
+  const year = yearMonth[0];
+  const month = yearMonth[1];
+  const monthId = createMonthId(year, month);
+
+  let monthData = USDaiMonthData.load(monthId);
+
+  if (monthData == null) {
+    monthData = new USDaiMonthData(monthId);
+    monthData.year = year;
+    monthData.month = month;
+    monthData.timestamp = getMonthStartTimestamp(year, month);
+    monthData.volume = BigInt.fromI32(0);
+    monthData.transferCount = BigInt.fromI32(0);
+  }
+
+  monthData.volume = monthData.volume.plus(event.params.value);
+  monthData.transferCount = monthData.transferCount.plus(BigInt.fromI32(1));
+  monthData.save();
+}

--- a/subgraph/src/utils/misc.ts
+++ b/subgraph/src/utils/misc.ts
@@ -7,3 +7,80 @@ export function bytesFromBigInt(bigInt: BigInt): Bytes {
 export function createEventID(event: ethereum.Event): string {
   return event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
 }
+
+// Constants for date calculations
+const SECONDS_PER_DAY: i32 = 86400;
+const DAYS_PER_YEAR: i32 = 365;
+const DAYS_PER_LEAP_YEAR: i32 = 366;
+
+// Days in each month (non-leap year)
+const DAYS_IN_MONTH: i32[] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isLeapYear(year: i32): boolean {
+  return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+}
+
+function getDaysInMonth(year: i32, month: i32): i32 {
+  if (month == 2 && isLeapYear(year)) {
+    return 29;
+  }
+  return DAYS_IN_MONTH[month - 1];
+}
+
+function getDaysInYear(year: i32): i32 {
+  return isLeapYear(year) ? DAYS_PER_LEAP_YEAR : DAYS_PER_YEAR;
+}
+
+/**
+ * Calculate year and month from Unix timestamp
+ * Returns [year, month] where month is 1-12
+ */
+export function getYearAndMonth(timestamp: BigInt): i32[] {
+  const totalDays = timestamp.div(BigInt.fromI32(SECONDS_PER_DAY)).toI32();
+
+  // Start from Unix epoch (1970-01-01)
+  let year: i32 = 1970;
+  let remainingDays = totalDays;
+
+  // Calculate year
+  while (remainingDays >= getDaysInYear(year)) {
+    remainingDays -= getDaysInYear(year);
+    year++;
+  }
+
+  // Calculate month
+  let month: i32 = 1;
+  while (remainingDays >= getDaysInMonth(year, month)) {
+    remainingDays -= getDaysInMonth(year, month);
+    month++;
+  }
+
+  return [year, month];
+}
+
+/**
+ * Get the Unix timestamp for the start of a given month
+ */
+export function getMonthStartTimestamp(year: i32, month: i32): BigInt {
+  let days: i32 = 0;
+
+  // Add days for years since 1970
+  for (let y: i32 = 1970; y < year; y++) {
+    days += getDaysInYear(y);
+  }
+
+  // Add days for months in current year
+  for (let m: i32 = 1; m < month; m++) {
+    days += getDaysInMonth(year, m);
+  }
+
+  return BigInt.fromI32(days).times(BigInt.fromI32(SECONDS_PER_DAY));
+}
+
+/**
+ * Create a month ID from year and month (e.g., "2026-01")
+ */
+export function createMonthId(year: i32, month: i32): Bytes {
+  const monthStr = month < 10 ? "0" + month.toString() : month.toString();
+  return Bytes.fromUTF8(year.toString() + "-" + monthStr);
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -25,3 +25,24 @@ dataSources:
             address,uint256,uint32)
           handler: handlePredepositVaultDeposit
       file: ./src/predeposit-vault.ts
+  - kind: ethereum
+    name: USDai
+    network: sepolia
+    source:
+      abi: USDai
+      address: "0xeb29fbaa2d509e43313c196a82f4ad75fa251285"
+      startBlock: 8311763
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - USDaiStats
+        - USDaiMonthData
+      abis:
+        - name: USDai
+          file: ../out/USDai.sol/USDai.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+      file: ./src/usdai.ts

--- a/subgraph/tests/usdai/usdai.test.ts
+++ b/subgraph/tests/usdai/usdai.test.ts
@@ -1,0 +1,255 @@
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { assert, beforeEach, clearStore, describe, test } from "matchstick-as";
+import { USDaiMonthData, USDaiStats } from "../../generated/schema";
+import { handleTransfer } from "../../src/usdai";
+import { ALICE, BOB, CHARLIE, createTransferEvent, TestTimestamps, TransferAmounts } from "./utils";
+
+const STATS_ID = Bytes.fromUTF8("stats");
+
+describe("USDaiStats", () => {
+  beforeEach(() => {
+    clearStore();
+  });
+
+  test("First transfer creates entity with correct values", () => {
+    const event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+
+    handleTransfer(event);
+
+    const stats = USDaiStats.load(STATS_ID);
+    assert.assertNotNull(stats);
+    assert.bigIntEquals(TransferAmounts.ONE_HUNDRED, stats!.totalVolume);
+    assert.bigIntEquals(BigInt.fromI32(1), stats!.transferCount);
+  });
+
+  test("Multiple transfers accumulate totalVolume correctly", () => {
+    const event1 = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+    const event2 = createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_THOUSAND, TestTimestamps.JAN_2024_MID);
+
+    handleTransfer(event1);
+    handleTransfer(event2);
+
+    const stats = USDaiStats.load(STATS_ID);
+    assert.assertNotNull(stats);
+
+    const expectedVolume = TransferAmounts.ONE_HUNDRED.plus(TransferAmounts.ONE_THOUSAND);
+    assert.bigIntEquals(expectedVolume, stats!.totalVolume);
+  });
+
+  test("Transfer count increments correctly", () => {
+    const event1 = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+    const event2 = createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_MID);
+    const event3 = createTransferEvent(CHARLIE, ALICE, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_END);
+
+    handleTransfer(event1);
+    handleTransfer(event2);
+    handleTransfer(event3);
+
+    const stats = USDaiStats.load(STATS_ID);
+    assert.assertNotNull(stats);
+    assert.bigIntEquals(BigInt.fromI32(3), stats!.transferCount);
+  });
+
+  test("Zero-value transfers are counted but add zero volume", () => {
+    const event1 = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+    const zeroEvent = createTransferEvent(BOB, CHARLIE, TransferAmounts.ZERO, TestTimestamps.JAN_2024_MID);
+
+    handleTransfer(event1);
+    handleTransfer(zeroEvent);
+
+    const stats = USDaiStats.load(STATS_ID);
+    assert.assertNotNull(stats);
+    assert.bigIntEquals(TransferAmounts.ONE_HUNDRED, stats!.totalVolume);
+    assert.bigIntEquals(BigInt.fromI32(2), stats!.transferCount);
+  });
+
+  test("Large amounts handled correctly", () => {
+    const event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_MILLION, TestTimestamps.JAN_2024_START);
+
+    handleTransfer(event);
+
+    const stats = USDaiStats.load(STATS_ID);
+    assert.assertNotNull(stats);
+    assert.bigIntEquals(TransferAmounts.ONE_MILLION, stats!.totalVolume);
+  });
+
+  test("Minimum amount (1 wei) handled correctly", () => {
+    const event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_WEI, TestTimestamps.JAN_2024_START);
+
+    handleTransfer(event);
+
+    const stats = USDaiStats.load(STATS_ID);
+    assert.assertNotNull(stats);
+    assert.bigIntEquals(TransferAmounts.ONE_WEI, stats!.totalVolume);
+  });
+});
+
+describe("USDaiMonthData", () => {
+  beforeEach(() => {
+    clearStore();
+  });
+
+  test("Month ID format is YYYY-MM with leading zeros", () => {
+    const event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+
+    handleTransfer(event);
+
+    const monthId = Bytes.fromUTF8("2024-01");
+    const monthData = USDaiMonthData.load(monthId);
+    assert.assertNotNull(monthData);
+  });
+
+  test("Correct year/month/timestamp fields set", () => {
+    const event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+
+    handleTransfer(event);
+
+    const monthId = Bytes.fromUTF8("2024-01");
+    const monthData = USDaiMonthData.load(monthId);
+    assert.assertNotNull(monthData);
+    assert.i32Equals(2024, monthData!.year);
+    assert.i32Equals(1, monthData!.month);
+    // January 2024 start timestamp
+    assert.bigIntEquals(BigInt.fromI32(1704067200), monthData!.timestamp);
+  });
+
+  test("Same-month transfers aggregate to single entity", () => {
+    const event1 = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+    const event2 = createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_THOUSAND, TestTimestamps.JAN_2024_MID);
+    const event3 = createTransferEvent(CHARLIE, ALICE, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_END);
+
+    handleTransfer(event1);
+    handleTransfer(event2);
+    handleTransfer(event3);
+
+    const monthId = Bytes.fromUTF8("2024-01");
+    const monthData = USDaiMonthData.load(monthId);
+    assert.assertNotNull(monthData);
+
+    const expectedVolume = TransferAmounts.ONE_HUNDRED.plus(TransferAmounts.ONE_THOUSAND).plus(
+      TransferAmounts.ONE_HUNDRED,
+    );
+    assert.bigIntEquals(expectedVolume, monthData!.volume);
+    assert.bigIntEquals(BigInt.fromI32(3), monthData!.transferCount);
+  });
+
+  test("Different months create separate entities", () => {
+    const janEvent = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+    const febEvent = createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_THOUSAND, TestTimestamps.FEB_2024_START);
+
+    handleTransfer(janEvent);
+    handleTransfer(febEvent);
+
+    const janMonthId = Bytes.fromUTF8("2024-01");
+    const febMonthId = Bytes.fromUTF8("2024-02");
+
+    const janData = USDaiMonthData.load(janMonthId);
+    const febData = USDaiMonthData.load(febMonthId);
+
+    assert.assertNotNull(janData);
+    assert.assertNotNull(febData);
+
+    assert.bigIntEquals(TransferAmounts.ONE_HUNDRED, janData!.volume);
+    assert.bigIntEquals(TransferAmounts.ONE_THOUSAND, febData!.volume);
+
+    assert.i32Equals(1, janData!.month);
+    assert.i32Equals(2, febData!.month);
+  });
+
+  test("Year boundary creates separate entities", () => {
+    const dec2024Event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.DEC_2024_END);
+    const jan2025Event = createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_THOUSAND, TestTimestamps.JAN_2025_START);
+
+    handleTransfer(dec2024Event);
+    handleTransfer(jan2025Event);
+
+    const dec2024Id = Bytes.fromUTF8("2024-12");
+    const jan2025Id = Bytes.fromUTF8("2025-01");
+
+    const dec2024Data = USDaiMonthData.load(dec2024Id);
+    const jan2025Data = USDaiMonthData.load(jan2025Id);
+
+    assert.assertNotNull(dec2024Data);
+    assert.assertNotNull(jan2025Data);
+
+    assert.i32Equals(2024, dec2024Data!.year);
+    assert.i32Equals(12, dec2024Data!.month);
+
+    assert.i32Equals(2025, jan2025Data!.year);
+    assert.i32Equals(1, jan2025Data!.month);
+  });
+
+  test("Leap year February handled correctly", () => {
+    const leapDayEvent = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.FEB_2024_LEAP_DAY);
+
+    handleTransfer(leapDayEvent);
+
+    const febMonthId = Bytes.fromUTF8("2024-02");
+    const febData = USDaiMonthData.load(febMonthId);
+
+    assert.assertNotNull(febData);
+    assert.i32Equals(2024, febData!.year);
+    assert.i32Equals(2, febData!.month);
+  });
+
+  test("Double-digit months work correctly", () => {
+    const event = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.DEC_2024_END);
+
+    handleTransfer(event);
+
+    const monthId = Bytes.fromUTF8("2024-12");
+    const monthData = USDaiMonthData.load(monthId);
+    assert.assertNotNull(monthData);
+    assert.i32Equals(12, monthData!.month);
+  });
+});
+
+describe("Integration Tests", () => {
+  beforeEach(() => {
+    clearStore();
+  });
+
+  test("Total stats volume equals sum of monthly volumes", () => {
+    const janEvent = createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START);
+    const febEvent = createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_THOUSAND, TestTimestamps.FEB_2024_START);
+    const marEvent = createTransferEvent(CHARLIE, ALICE, TransferAmounts.ONE_MILLION, TestTimestamps.MAR_2024_START);
+
+    handleTransfer(janEvent);
+    handleTransfer(febEvent);
+    handleTransfer(marEvent);
+
+    const stats = USDaiStats.load(STATS_ID);
+    const janData = USDaiMonthData.load(Bytes.fromUTF8("2024-01"));
+    const febData = USDaiMonthData.load(Bytes.fromUTF8("2024-02"));
+    const marData = USDaiMonthData.load(Bytes.fromUTF8("2024-03"));
+
+    assert.assertNotNull(stats);
+    assert.assertNotNull(janData);
+    assert.assertNotNull(febData);
+    assert.assertNotNull(marData);
+
+    const monthlySum = janData!.volume.plus(febData!.volume).plus(marData!.volume);
+    assert.bigIntEquals(stats!.totalVolume, monthlySum);
+  });
+
+  test("Total transfer count equals sum of monthly counts", () => {
+    // 2 transfers in January
+    handleTransfer(createTransferEvent(ALICE, BOB, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_START));
+    handleTransfer(createTransferEvent(BOB, CHARLIE, TransferAmounts.ONE_HUNDRED, TestTimestamps.JAN_2024_MID));
+
+    // 1 transfer in February
+    handleTransfer(createTransferEvent(CHARLIE, ALICE, TransferAmounts.ONE_HUNDRED, TestTimestamps.FEB_2024_START));
+
+    const stats = USDaiStats.load(STATS_ID);
+    const janData = USDaiMonthData.load(Bytes.fromUTF8("2024-01"));
+    const febData = USDaiMonthData.load(Bytes.fromUTF8("2024-02"));
+
+    assert.assertNotNull(stats);
+    assert.assertNotNull(janData);
+    assert.assertNotNull(febData);
+
+    const monthlyCountSum = janData!.transferCount.plus(febData!.transferCount);
+    assert.bigIntEquals(stats!.transferCount, monthlyCountSum);
+    assert.bigIntEquals(BigInt.fromI32(3), stats!.transferCount);
+  });
+});

--- a/subgraph/tests/usdai/utils.ts
+++ b/subgraph/tests/usdai/utils.ts
@@ -1,0 +1,90 @@
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+import { Transfer as TransferEvent } from "../../generated/USDai/USDai";
+
+// Test addresses
+export const ALICE = Address.fromString("0x1111111111111111111111111111111111111111");
+export const BOB = Address.fromString("0x2222222222222222222222222222222222222222");
+export const CHARLIE = Address.fromString("0x3333333333333333333333333333333333333333");
+export const ZERO_ADDRESS = Address.fromString("0x0000000000000000000000000000000000000000");
+
+// Known Unix timestamps for testing
+export class TestTimestamps {
+  // January 2024
+  static JAN_2024_START: BigInt = BigInt.fromI32(1704067200); // 2024-01-01 00:00:00 UTC
+  static JAN_2024_MID: BigInt = BigInt.fromI32(1705312800); // 2024-01-15 10:00:00 UTC
+  static JAN_2024_END: BigInt = BigInt.fromI32(1706745599); // 2024-01-31 23:59:59 UTC
+
+  // February 2024 (leap year)
+  static FEB_2024_START: BigInt = BigInt.fromI32(1706745600); // 2024-02-01 00:00:00 UTC
+  static FEB_2024_LEAP_DAY: BigInt = BigInt.fromI32(1709208000); // 2024-02-29 12:00:00 UTC
+
+  // March 2024
+  static MAR_2024_START: BigInt = BigInt.fromI32(1709251200); // 2024-03-01 00:00:00 UTC
+
+  // December 2023
+  static DEC_2023_MID: BigInt = BigInt.fromI32(1702396800); // 2023-12-12 16:00:00 UTC
+
+  // December 2024
+  static DEC_2024_END: BigInt = BigInt.fromI32(1735689599); // 2024-12-31 23:59:59 UTC
+
+  // January 2025
+  static JAN_2025_START: BigInt = BigInt.fromI32(1735689600); // 2025-01-01 00:00:00 UTC
+
+  // Unix epoch
+  static EPOCH: BigInt = BigInt.fromI32(0); // 1970-01-01 00:00:00 UTC
+
+  // February 2023 (non-leap year)
+  static FEB_2023_END: BigInt = BigInt.fromI32(1677628799); // 2023-02-28 23:59:59 UTC
+  static MAR_2023_START: BigInt = BigInt.fromI32(1677628800); // 2023-03-01 00:00:00 UTC
+}
+
+// Common transfer amounts (in wei - USDai has 18 decimals)
+export class TransferAmounts {
+  static ONE_WEI: BigInt = BigInt.fromI32(1);
+  static ONE: BigInt = BigInt.fromI32(10).pow(18); // 1 USDai = 10^18 wei
+  static ONE_HUNDRED: BigInt = TransferAmounts.ONE.times(BigInt.fromI32(100));
+  static ONE_THOUSAND: BigInt = TransferAmounts.ONE.times(BigInt.fromI32(1000));
+  static ONE_MILLION: BigInt = TransferAmounts.ONE.times(BigInt.fromI32(1000000));
+  static ZERO: BigInt = BigInt.fromI32(0);
+}
+
+/**
+ * Creates a mock Transfer event for testing
+ */
+export function createTransferEvent(
+  from: Address,
+  to: Address,
+  value: BigInt,
+  timestamp: BigInt
+): TransferEvent {
+  const mockEvent = newMockEvent();
+
+  // Set timestamp on block
+  mockEvent.block.timestamp = timestamp;
+
+  // Create Transfer event
+  const transferEvent = new TransferEvent(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+    mockEvent.receipt
+  );
+
+  // Set up parameters
+  transferEvent.parameters = new Array();
+
+  const fromParam = new ethereum.EventParam("from", ethereum.Value.fromAddress(from));
+  const toParam = new ethereum.EventParam("to", ethereum.Value.fromAddress(to));
+  const valueParam = new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value));
+
+  transferEvent.parameters.push(fromParam);
+  transferEvent.parameters.push(toParam);
+  transferEvent.parameters.push(valueParam);
+
+  return transferEvent;
+}

--- a/subgraph/tests/utils/date-utils.test.ts
+++ b/subgraph/tests/utils/date-utils.test.ts
@@ -1,0 +1,168 @@
+import { assert, describe, test } from "matchstick-as";
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { getYearAndMonth, getMonthStartTimestamp, createMonthId } from "../../src/utils";
+
+describe("getYearAndMonth", () => {
+  test("Unix epoch returns [1970, 1]", () => {
+    const result = getYearAndMonth(BigInt.fromI32(0));
+    assert.i32Equals(1970, result[0]);
+    assert.i32Equals(1, result[1]);
+  });
+
+  test("Known date: 2024-01-01 00:00:00 UTC", () => {
+    // January 1, 2024 00:00:00 UTC = 1704067200
+    const result = getYearAndMonth(BigInt.fromI32(1704067200));
+    assert.i32Equals(2024, result[0]);
+    assert.i32Equals(1, result[1]);
+  });
+
+  test("Known date: 2024-06-15 12:00:00 UTC (mid-year)", () => {
+    // June 15, 2024 12:00:00 UTC = 1718452800
+    const result = getYearAndMonth(BigInt.fromI32(1718452800));
+    assert.i32Equals(2024, result[0]);
+    assert.i32Equals(6, result[1]);
+  });
+
+  test("Known date: 2024-12-31 23:59:59 UTC", () => {
+    // December 31, 2024 23:59:59 UTC = 1735689599
+    const result = getYearAndMonth(BigInt.fromI32(1735689599));
+    assert.i32Equals(2024, result[0]);
+    assert.i32Equals(12, result[1]);
+  });
+
+  test("Month boundary: Jan 31 23:59:59 vs Feb 1 00:00:00", () => {
+    // January 31, 2024 23:59:59 UTC = 1706745599
+    const janEnd = getYearAndMonth(BigInt.fromI32(1706745599));
+    assert.i32Equals(2024, janEnd[0]);
+    assert.i32Equals(1, janEnd[1]);
+
+    // February 1, 2024 00:00:00 UTC = 1706745600
+    const febStart = getYearAndMonth(BigInt.fromI32(1706745600));
+    assert.i32Equals(2024, febStart[0]);
+    assert.i32Equals(2, febStart[1]);
+  });
+
+  test("Year boundary: Dec 31 2024 vs Jan 1 2025", () => {
+    // December 31, 2024 23:59:59 UTC = 1735689599
+    const dec2024 = getYearAndMonth(BigInt.fromI32(1735689599));
+    assert.i32Equals(2024, dec2024[0]);
+    assert.i32Equals(12, dec2024[1]);
+
+    // January 1, 2025 00:00:00 UTC = 1735689600
+    const jan2025 = getYearAndMonth(BigInt.fromI32(1735689600));
+    assert.i32Equals(2025, jan2025[0]);
+    assert.i32Equals(1, jan2025[1]);
+  });
+
+  test("Leap year: Feb 29 2024", () => {
+    // February 29, 2024 12:00:00 UTC = 1709208000
+    const result = getYearAndMonth(BigInt.fromI32(1709208000));
+    assert.i32Equals(2024, result[0]);
+    assert.i32Equals(2, result[1]);
+  });
+
+  test("Non-leap year: Feb 28 2023 to Mar 1 2023", () => {
+    // February 28, 2023 23:59:59 UTC = 1677628799
+    const feb28 = getYearAndMonth(BigInt.fromI32(1677628799));
+    assert.i32Equals(2023, feb28[0]);
+    assert.i32Equals(2, feb28[1]);
+
+    // March 1, 2023 00:00:00 UTC = 1677628800
+    const mar1 = getYearAndMonth(BigInt.fromI32(1677628800));
+    assert.i32Equals(2023, mar1[0]);
+    assert.i32Equals(3, mar1[1]);
+  });
+
+  test("Handles large timestamp (far future)", () => {
+    // January 1, 2050 00:00:00 UTC = 2524608000
+    const result = getYearAndMonth(BigInt.fromI64(2524608000));
+    assert.i32Equals(2050, result[0]);
+    assert.i32Equals(1, result[1]);
+  });
+});
+
+describe("getMonthStartTimestamp", () => {
+  test("January 1970 returns 0", () => {
+    const result = getMonthStartTimestamp(1970, 1);
+    assert.bigIntEquals(BigInt.fromI32(0), result);
+  });
+
+  test("January 2024 = 1704067200", () => {
+    const result = getMonthStartTimestamp(2024, 1);
+    assert.bigIntEquals(BigInt.fromI32(1704067200), result);
+  });
+
+  test("February 2024 = 1706745600", () => {
+    const result = getMonthStartTimestamp(2024, 2);
+    assert.bigIntEquals(BigInt.fromI32(1706745600), result);
+  });
+
+  test("March 2024 accounts for leap day", () => {
+    // In a leap year, February has 29 days, so March starts on day 60 of the year
+    // March 1, 2024 = 1709251200
+    const result = getMonthStartTimestamp(2024, 3);
+    assert.bigIntEquals(BigInt.fromI32(1709251200), result);
+  });
+
+  test("March 2023 (non-leap year)", () => {
+    // In non-leap year, February has 28 days, so March starts on day 59 of the year
+    // March 1, 2023 = 1677628800
+    const result = getMonthStartTimestamp(2023, 3);
+    assert.bigIntEquals(BigInt.fromI32(1677628800), result);
+  });
+
+  test("December 2024", () => {
+    // December 1, 2024 = 1733011200
+    const result = getMonthStartTimestamp(2024, 12);
+    assert.bigIntEquals(BigInt.fromI32(1733011200), result);
+  });
+
+  test("January 2025", () => {
+    // January 1, 2025 = 1735689600
+    const result = getMonthStartTimestamp(2025, 1);
+    assert.bigIntEquals(BigInt.fromI32(1735689600), result);
+  });
+
+  test("Consistency: getMonthStartTimestamp output parses back correctly", () => {
+    // Get start of June 2024
+    const timestamp = getMonthStartTimestamp(2024, 6);
+    // Parse it back
+    const result = getYearAndMonth(timestamp);
+    assert.i32Equals(2024, result[0]);
+    assert.i32Equals(6, result[1]);
+  });
+});
+
+describe("createMonthId", () => {
+  test("Single-digit months get leading zero", () => {
+    const jan = createMonthId(2024, 1);
+    assert.bytesEquals(Bytes.fromUTF8("2024-01"), jan);
+
+    const sep = createMonthId(2024, 9);
+    assert.bytesEquals(Bytes.fromUTF8("2024-09"), sep);
+  });
+
+  test("Double-digit months work correctly", () => {
+    const oct = createMonthId(2024, 10);
+    assert.bytesEquals(Bytes.fromUTF8("2024-10"), oct);
+
+    const dec = createMonthId(2024, 12);
+    assert.bytesEquals(Bytes.fromUTF8("2024-12"), dec);
+  });
+
+  test("IDs are unique per year-month", () => {
+    const jan2024 = createMonthId(2024, 1);
+    const jan2025 = createMonthId(2025, 1);
+    const feb2024 = createMonthId(2024, 2);
+
+    // All should be different
+    assert.assertTrue(jan2024.notEqual(jan2025));
+    assert.assertTrue(jan2024.notEqual(feb2024));
+    assert.assertTrue(jan2025.notEqual(feb2024));
+  });
+
+  test("Format is consistent YYYY-MM", () => {
+    const id = createMonthId(2030, 7);
+    assert.bytesEquals(Bytes.fromUTF8("2030-07"), id);
+  });
+});


### PR DESCRIPTION
# Add USDai Stats and Transfer Volume History to Subgraph

## Summary

Adds statistics tracking and monthly transfer volume history to the USDai subgraph. Tracks cumulative transfer statistics and aggregates transfer data by month.

## Changes

- **Schema**: Added `USDaiStats` (totalVolume, transferCount) and `USDaiMonthData` (monthly volume and transfer counts)
- **Handler**: Implemented `handleTransfer` to update cumulative stats and monthly aggregations
- **Utilities**: Added date/time functions for year/month extraction and month start timestamp calculation with leap year support
- **Tests**: Added matchstick-as testing framework with comprehensive test suite covering stats accumulation, monthly aggregation, edge cases, and integration tests

## Testing

Run tests with `npm test` in the subgraph directory. Test suite covers volume accumulation, transfer counting, month boundaries, year transitions, leap years, and integration scenarios.

## Technical Details

- Month IDs use "YYYY-MM" format
- Proper leap year handling in date calculations
- Stats entity uses singleton pattern with fixed ID